### PR TITLE
Added installed update detection and ability to install updates without logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -99,7 +99,8 @@ pddeployreceipt="/Library/Application Support/JAMF/Receipts/patchooDeploy" # thi
 
 msgtitlenewsoft="New Software Available"
 msgnewsoftware="Evernote IT has made the following updates available"
-msginstallnow="Evernote IT will install the following updates. 
+msginstallnow="
+The updates do not require a reboot and will be installed now.
 You may be required to close certain programs during the update. 
 Please save your work then click 'Install' to proceed."
 msginstalllater="
@@ -502,20 +503,20 @@ checkASU()
 		if [ "$(cat "$swupdateout" | grep "\[restart\]")" != "" ]
 		then
 			touch "$pkgdatafolder/.restart-required"
-		else
+#		else
 		    # install the updates
-		    softwareupdate -i -a
-		    softwareupdate -la > "$swupdateout"
-		    if [ "$(cat "$swupdateout" | grep "\*")" != "" ]
-		    then
-		        secho "Error with update install. Manual intervention required."
-		    else
-		        secho "Updates installed successfully. Cleaning up..."
-		        defaults write "$prefs" InstallsAvail -string "No"
-	        	installsavail="No"
-	        	rm -R "$pkgdatafolder"
-	            rm /tmp/.patchoo-install
-	        fi
+#		    softwareupdate -i -a
+#		    softwareupdate -la > "$swupdateout"
+#		    if [ "$(cat "$swupdateout" | grep "\*")" != "" ]
+#		    then
+#		        secho "Error with update install. Manual intervention required."
+#		    else
+#		        secho "Updates installed successfully. Cleaning up..."
+#		        defaults write "$prefs" InstallsAvail -string "No"
+#	        	installsavail="No"
+#	        	rm -R "$pkgdatafolder"
+#	            rm /tmp/.patchoo-install
+#	        fi
 		fi
 	else
 		secho "no updates found. yo"
@@ -827,16 +828,17 @@ promptInstall()
 		promptmode="--selfservice"
 		rm "$datafolder/.patchoo-selfservice-check"
 	fi
-	
-	if [ ! -f "/tmp/.patchoo-restart" ]
-	then
-		promptmode="--norestart"
-	fi
 
 	# there are waiting updates ... make a message for the user prompt	
 	secho "prompting user..."
 	message=""
 	
+	# prompt user to install packages if no restart required
+	if [ ! -f "/tmp/.patchoo-restart" ]
+	then
+		promptmode="--norestart"
+	fi
+
 	if [ -f "$casppkginfo" ]
 	then
 		while read line
@@ -981,6 +983,10 @@ promptInstall()
 		
 		"Install" )
 			secho "Installing updates..."
+			touch /tmp/.patchoo-install
+			echo $$ > /tmp/.patchoo-install-pid
+			preInstallWarnings
+			installSoftware
 			return
 		;;
 		

--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -25,15 +25,15 @@ apipass="apipass"
 datafolder="/Library/Application Support/patchoo"
 pkgdatafolder="$datafolder/pkgdata"
 prefs="$datafolder/com.github.patchoo"
-cdialog="/Library/Application Support/cocoaDialog.app"	#please specify the appbundle rather than the actual binary
+cdialog="/Applications/Utilities/cocoaDialog.app"	#please specify the appbundle rather than the actual binary
 jamfhelper="/Library/Application Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper"
 
 # if you are using a self signed cert for you jss, tell curl to allow it.
-selfsignedjsscert=false
+selfsignedjsscert=true
 
 # users can defer x update prompts
 defermode=true
-defaultdeferthresold="4"
+defaultdeferthresold="10"
 
 # REALLY forces a logout when defers run out
 nastymode=true
@@ -98,15 +98,13 @@ pddeployreceipt="/Library/Application Support/JAMF/Receipts/patchooDeploy" # thi
 #########################################
 
 msgtitlenewsoft="New Software Available"
-msgnewsoftware="Evernote IT has made the following updates available"
+msgnewsoftware="The following new software is available"
 msginstallnow="
 The updates do not require a reboot, however, you may be 
 required to close certain programs during the update.
  
 Please save your work then click 'Install' to proceed."
-msginstalllater="
-NOTE: You can perform the installation later by clicking
-'Check for New Software' under Updates in Self Service"
+msginstalllater="(You can perform the installation later via Self Service)"
 msgnewsoftforced="The following software must be installed now!"
 msgbootstrap="Mac is provisioning. Do not interrupt or power off."
 msgbootstapdeployholdingpattern="Awaiting provisioning information. Your admin has been notified."

--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -133,7 +133,7 @@ Please ensure you are connected to AC Power! Your computer will restart and the 
 IT IS VERY IMPORTANT YOU DO NOT INTERRUPT THIS PROCESS AS IT MAY LEAVE YOUR MAC INOPERABLE"
 
 iconsize="72"
-dialogtimeout="210"
+dialogtimeout="3630"
 
 lockscreenlogo="/System/Library/CoreServices/Installer.app/Contents/Resources/Installer.icns" # used for fauxLogout (ARD LockScreen will display this) and bootstrap
 

--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -131,7 +131,7 @@ Please ensure you are connected to AC Power! Your computer will restart and the 
 IT IS VERY IMPORTANT YOU DO NOT INTERRUPT THIS PROCESS AS IT MAY LEAVE YOUR MAC INOPERABLE"
 
 iconsize="72"
-dialogtimeout="3630"
+dialogtimeout="210"
 
 lockscreenlogo="/System/Library/CoreServices/Installer.app/Contents/Resources/Installer.icns" # used for fauxLogout (ARD LockScreen will display this) and bootstrap
 
@@ -222,6 +222,8 @@ then
 fi
 
 # set defaults for defer and blockingapp counts
+
+# defer is the # of times a user can defer updates
 deferthreshold=$(defaults read "$prefs" DeferThreshold 2> /dev/null)
 if [ "$?" != "0" ]
 then
@@ -234,9 +236,6 @@ then
 	defaults write "$prefs" DeferCount -int 0
 	defercount=0
 fi
-
-# defer is the # of times a user can defer updates
-
 
 # blockingapp is the # of times a blocking app can block a prompt
 blockappthreshold=$(defaults read "$prefs" BlockingAppThreshold 2> /dev/null)
@@ -508,27 +507,13 @@ checkASU()
 		then
 			secho "clearing restart flag"
 			rm "$pkgdatafolder/.restart-required"
-#		else
-		    # install the updates
-#		    softwareupdate -i -a
-#		    softwareupdate -la > "$swupdateout"
-#		    if [ "$(cat "$swupdateout" | grep "\*")" != "" ]
-#		    then
-#		        secho "Error with update install. Manual intervention required."
-#		    else
-#		        secho "Updates installed successfully. Cleaning up..."
-#		        defaults write "$prefs" InstallsAvail -string "No"
-#	        	installsavail="No"
-#	        	rm -R "$pkgdatafolder"
-#	            rm /tmp/.patchoo-install
-#	        fi
 		fi
 	else
-		secho "no updates found. yo"
+		secho "no updates found."
 		defaults write "$prefs" InstallsAvail -string "No"
 		installsavail="No"
 		rm -R "$pkgdatafolder"
-	    rm /tmp/.patchoo-install
+	   	rm /tmp/.patchoo-install
 	fi
 	rm "$swupdateout"
 }
@@ -951,7 +936,7 @@ promptInstall()
 					if [ $restart == "yes" ] && ([ $deferremain -eq 0 ] || [ $deferremain -lt 0 ])
 					then
 						# if the defercounter has run out and restart required, force installation with restart! set timeout to 60 minutes
-						dialogtimeout="3630"
+						dialogtimeout="1830"
 						answer=$(displayDialog "$message" "$msgtitlenewsoft" "$msgnewsoftforced" "package" "Logout and Install...")
 						# if it's nastymode (tm) we Logout and Install no matter what
 						[ $nastymode ] && answer="Logout and Install..."
@@ -959,7 +944,7 @@ promptInstall()
 					elif [ $deferremain -eq 0 ] || [ $deferremain -lt 0 ]
 					then
 						# if the defercounter has run out, force installation without restart! set timeout to 60 minutes
-						dialogtimeout="3630"
+						dialogtimeout="1830"
 						answer=$(displayDialog "$message" "$msgtitlenewsoft" "$msgnewsoftforced" "package" "Install...")
 						# if it's nastymode (tm) we Logout and Install no matter what
 						[ $nastymode ] && answer="Install..."

--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -98,7 +98,10 @@ pddeployreceipt="/Library/Application Support/JAMF/Receipts/patchooDeploy" # thi
 #########################################
 
 msgtitlenewsoft="New Software Available"
-msgnewsoftware="Evernote IT has made the following new software available"
+msgnewsoftware="Evernote IT has made the following updates available"
+msginstallnow="Evernote IT will install the following updates. 
+You may be required to close certain programs during the update. 
+Please save your work then click 'Install' to proceed."
 msginstalllater="
 NOTE: You can perform the installation later by clicking
 'Check for New Software' under Updates in Self Service"
@@ -824,6 +827,11 @@ promptInstall()
 		promptmode="--selfservice"
 		rm "$datafolder/.patchoo-selfservice-check"
 	fi
+	
+	if [ ! -f "/tmp/.patchoo-restart" ]
+	then
+		promptmode="--norestart"
+	fi
 
 	# there are waiting updates ... make a message for the user prompt	
 	secho "prompting user..."
@@ -886,6 +894,14 @@ promptInstall()
 				;;
 			esac
 		;;
+		"--norestart" )
+			#
+			# install updates without restarting. warn user that programs may be closed 
+			#
+			makeMessage ""
+			makeMessage "$msginstallnow"
+			answer=$(displayDialog "$message" "$msgtitlenewsoft" "$msgnewsoftware" "package" "Install" )
+		;;		
 		
 		"--selfservice" )
 			#
@@ -939,7 +955,7 @@ promptInstall()
 						# if it's nastymode (tm) we Logout and Install no matter what
 						[ $nastymode ] && answer="Logout and Install..."
 						secho "FORCING INSTALL!"
-					else
+					elsif 
 						# prompt user with defer option
 						makeMessage ""
 						makeMessage "$msginstalllater"
@@ -962,6 +978,11 @@ promptInstall()
 
 	# process the answer.
 	case $answer in
+		
+		"Install" )
+			secho "Installing updates..."
+			return
+		;;
 		
 		"Logout and Install..." )
 			# this flags for install, and logs out the user, logout policy picks up the install flag and does installations.


### PR DESCRIPTION
I added code to detect and ignore any updates that have been installed by an external process (either manually or via App store updates). I also added code to check if a restart is necessary. If not, the script will prompt the user as usual but not log them out of the system upon install. I stripped out our company specific settings so there are a few extra commits where I reverted the script settings (timeouts, messages, etc) back to their defaults.