### PR TITLE
Update the path to the NWO of things

### DIFF
--- a/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-every120.plist
+++ b/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-every120.plist
@@ -6,7 +6,7 @@
 	<string>com.github.patchoo-trigger-every120</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/sbin/jamf</string>
+		<string>/usr/local/bin/jamf</string>
 		<string>policy</string>
 		<string>-trigger</string>
 		<string>every120</string>

--- a/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-patchoo.plist
+++ b/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-patchoo.plist
@@ -6,7 +6,7 @@
 	<string>com.github.patchoo-trigger-patchoo</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/sbin/jamf</string>
+		<string>/usr/localbin/jamf</string>
 		<string>policy</string>
 		<string>-trigger</string>
 		<string>patchoo</string>

--- a/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-patchoo.plist
+++ b/triggers/Library/LaunchDaemons/com.github.patchoo-trigger-patchoo.plist
@@ -6,7 +6,7 @@
 	<string>com.github.patchoo-trigger-patchoo</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/localbin/jamf</string>
+		<string>/usr/local/bin/jamf</string>
 		<string>policy</string>
 		<string>-trigger</string>
 		<string>patchoo</string>


### PR DESCRIPTION
We really need to go to /usr/local/bin as of a recent OSX version / is no longer a viable option (with good reason).